### PR TITLE
feat: redesign post header with prominent title and inline meta

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,26 +4,15 @@ layout: default
 <article class="post">
     <div class="post-container">
         <header class="post-header">
-            <div class="post-header-top">
-                <button onclick="window.history.back()" class="back-button">Back</button>
-            </div>
             <h1 class="post-title">{{ page.title }}</h1>
             {% if page.description %}
             <p class="post-description">{{ page.description }}</p>
             {% endif %}
-            <div class="post-meta">
-                <span class="date-category">
-                    <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
-                    {% if page.category %} • <a href="{{ '/categories' | relative_url }}#{{ page.category | slugify }}" class="category-link">{{ page.category }}</a>{% endif %}
-                </span>
+            <div class="post-meta-inline">
+                <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+                {% if page.category %}<span class="meta-separator">•</span><a href="{{ '/categories' | relative_url }}#{{ page.category | slugify }}" class="category-link">{{ page.category }}</a>{% endif %}
+                {% if page.tags.size > 0 %}{% for tag in page.tags %}<span class="meta-separator">•</span><a href="{{ '/tags' | relative_url }}#{{ tag | slugify }}" class="tag-inline">#{{ tag }}</a>{% endfor %}{% endif %}
             </div>
-            {% if page.tags.size > 0 %}
-            <div class="tags post-tags">
-                {% for tag in page.tags %}
-                <a href="{{ '/tags' | relative_url }}#{{ tag | slugify }}" class="tag">{{ tag }}</a>
-                {% endfor %}
-            </div>
-            {% endif %}
         </header>
 
         <div class="post-content">
@@ -33,338 +22,93 @@ layout: default
 </article>
 
 <script>
-// Enhanced code block processing for better responsiveness
+// Code block processing with integrated copy button
 document.addEventListener('DOMContentLoaded', function() {
-    // Highlight blocks are now handled by copy-code.js
-    
-    // Process code blocks
+    // Initialize Highlight.js
+    if (typeof hljs !== 'undefined') {
+        hljs.highlightAll();
+    }
+
+    // Add code block headers (language indicator + copy button)
     document.querySelectorAll('pre code').forEach(function(codeBlock) {
-        // Skip if already processed
-        if (codeBlock.parentElement.previousElementSibling && codeBlock.parentElement.previousElementSibling.classList.contains('code-header')) return;
-        
         const pre = codeBlock.parentElement;
-        const language = codeBlock.className.match(/language-([^\s]*)/)?.[1] || '';
-        
-        // Create code header
+
+        // Skip if already processed
+        if (pre.dataset.codeProcessed) {
+            return;
+        }
+
+        // Mark as processed
+        pre.dataset.codeProcessed = 'true';
+
+        // Extract language from class name
+        const languageMatch = codeBlock.className.match(/language-(\w+)/);
+        const language = languageMatch ? languageMatch[1] : 'Code';
+
+        // Create code header with language indicator and copy button
         const codeHeader = document.createElement('div');
         codeHeader.className = 'code-header';
-        
-        // Add language indicator if available
-        if (language) {
-            const languageIndicator = document.createElement('span');
-            languageIndicator.className = 'language-indicator';
-            languageIndicator.textContent = language;
-            codeHeader.appendChild(languageIndicator);
-        }
-        
-        // Create actions container
-        const codeActions = document.createElement('div');
-        codeActions.className = 'code-actions';
-        
-        // Create toggle height button
-        const toggleButton = document.createElement('button');
-        toggleButton.className = 'toggle-code-height';
-        toggleButton.textContent = 'Expand';
-        toggleButton.addEventListener('click', function() {
-            const preElement = pre;
-            const wrapper = preElement.closest('.code-block-wrapper');
-            
-            if (preElement.classList.contains('code-expanded')) {
-                // Collapse
-                preElement.classList.remove('code-expanded');
-                if (wrapper) wrapper.classList.remove('code-expanded');
-                toggleButton.textContent = 'Expand';
-                
-                // Restore responsive max-height and font size
-                const screenWidth = window.innerWidth;
-                if (screenWidth <= 480) {
-                    preElement.style.maxHeight = '450px';
-                    if (wrapper) wrapper.style.maxHeight = '450px';
-                } else if (screenWidth <= 768) {
-                    preElement.style.maxHeight = '550px';
-                    if (wrapper) wrapper.style.maxHeight = '550px';
-                } else {
-                    preElement.style.maxHeight = '650px';
-                    if (wrapper) wrapper.style.maxHeight = '650px';
-                }
-                }
-            } else {
-                // Expand
-                preElement.classList.add('code-expanded');
-                if (wrapper) wrapper.classList.add('code-expanded');
-                toggleButton.textContent = 'Collapse';
-            }
-            
-            // Recheck overflow to update indicators
-            checkCodeBlockOverflow();
-        });
-        
-        // IMPORTANT: We don't add a copy button here anymore
-        // Copy button functionality is now entirely handled by copy-code.js
-        
-        // Add toggle button to actions container
-        codeActions.appendChild(toggleButton);
-        
-        // Add actions container to header
-        codeHeader.appendChild(codeActions);
-        
-        // Insert the header before the pre element
+        codeHeader.innerHTML = `
+            <span class="language-indicator">${language}</span>
+            <button class="copy-button" aria-label="Copy code">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+            </button>
+        `;
+
+        // Insert header before pre element
         pre.parentNode.insertBefore(codeHeader, pre);
-        
-        // Add a wrapper div with proper width constraints
-        if (!pre.parentNode.classList.contains('code-block-wrapper')) {
-            const wrapper = document.createElement('div');
-            wrapper.className = 'code-block-wrapper';
-            pre.parentNode.insertBefore(wrapper, pre);
-            wrapper.appendChild(pre);
-        }
-        
-        // Special handling for code block to ensure horizontal scrolling works correctly
-        pre.style.maxWidth = '100%';
-        pre.style.boxSizing = 'border-box';
-        pre.style.overflowX = 'auto';
-        
-        // Ensure code element can expand to its natural width while being scrollable
-        codeBlock.style.display = 'block';
-        codeBlock.style.minWidth = '100%';
-        codeBlock.style.width = 'max-content';
-        codeBlock.style.boxSizing = 'border-box';
-        
-        // Add line numbers if they don't exist yet
-        if (!pre.classList.contains('line-numbers-added')) {
-            // Get code content and split into lines
-            const codeContent = codeBlock.textContent;
-            const codeLines = codeContent.split('\n');
-            
-            // Clear existing code and replace with table layout
-            codeBlock.textContent = '';
-            codeBlock.style.display = 'block';
-            codeBlock.style.width = '100%';
-            
-            // Add each line with line number
-            codeLines.forEach((line, index) => {
-                // Line row
-                const lineRow = document.createElement('div');
-                lineRow.className = 'code-line-row';
-                
-                // Line number
-                const lineNumber = document.createElement('span');
-                lineNumber.className = 'line-number';
-                lineNumber.textContent = index + 1;
-                
-                // Line content
-                const lineContent = document.createElement('span');
-                lineContent.className = 'line-content';
-                lineContent.textContent = line;
-                
-                // Add to row and then to table
-                lineRow.appendChild(lineNumber);
-                lineRow.appendChild(lineContent);
-                codeBlock.appendChild(lineRow);
+
+        // Setup copy button functionality
+        const copyButton = codeHeader.querySelector('.copy-button');
+
+        copyButton.addEventListener('click', function() {
+            // Get the code content
+            let codeText;
+            const codeElement = pre.querySelector('code');
+            if (codeElement) {
+                codeText = codeElement.textContent;
+            } else {
+                codeText = pre.textContent;
+            }
+
+            // Copy to clipboard
+            navigator.clipboard.writeText(codeText).then(() => {
+                // Show success state
+                copyButton.classList.add('copied');
+                copyButton.innerHTML = `
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="20 6 9 17 4 12"></polyline>
+                    </svg>
+                `;
+
+                // Reset after 2 seconds
+                setTimeout(() => {
+                    copyButton.classList.remove('copied');
+                    copyButton.innerHTML = `
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                        </svg>
+                    `;
+                }, 2000);
+            }).catch(err => {
+                console.error('Failed to copy code: ', err);
             });
-            
-            pre.classList.add('line-numbers-added');
-        }
+        });
     });
-    
+
     // Add IDs to headings for direct linking
     const postContent = document.querySelector('.post-content');
-    
     if (postContent) {
         const headings = postContent.querySelectorAll('h2, h3, h4');
-        
-        if (headings.length > 0) {
-            headings.forEach((heading, index) => {
-                // Add ID to heading if it doesn't have one
-                if (!heading.id) {
-                    heading.id = `heading-${index}`;
-                }
-            });
-        }
-    }
-    
-    // Fix potential overflow issues by checking pre widths and heights
-    function checkCodeBlockOverflow() {
-        document.querySelectorAll('pre').forEach(pre => {
-            // Reset any previous styles that might be causing issues
-            pre.style.width = '100%';
-            pre.style.maxWidth = '100%';
-            pre.style.overflowX = 'auto';
-            pre.style.overflowY = 'auto';
-            
-            // Apply responsive max-height and font size based on screen width if not expanded
-            if (!pre.classList.contains('code-expanded')) {
-                const screenWidth = window.innerWidth;
-                if (screenWidth <= 480) {
-                    pre.style.maxHeight = '450px'; // Mobile screens
-                    pre.style.fontSize = '0.8rem'; // Smaller font for mobile
-                    if (pre.querySelector('code')) {
-                        pre.querySelector('code').style.fontSize = '0.8rem';
-                    }
-                } else if (screenWidth <= 768) {
-                    pre.style.maxHeight = '550px'; // Medium screens
-                    pre.style.fontSize = '0.85rem'; // Smaller font for medium screens
-                    if (pre.querySelector('code')) {
-                        pre.querySelector('code').style.fontSize = '0.85rem';
-                    }
-                } else {
-                    pre.style.maxHeight = '650px'; // Large screens
-                    pre.style.fontSize = '0.85rem'; // Normal font size for large screens
-                    if (pre.querySelector('code')) {
-                        pre.querySelector('code').style.fontSize = '0.85rem';
-                    }
-                }
-            }
-            
-            // Make sure the wrapper is properly scrollable
-            const wrapper = pre.closest('.code-block-wrapper');
-            if (wrapper) {
-                wrapper.style.overflowX = 'auto';
-                wrapper.style.overflowY = 'auto';
-                wrapper.style.maxWidth = '100%';
-                
-                // Apply responsive max-height based on screen width if not expanded
-                if (!wrapper.classList.contains('code-expanded')) {
-                    const screenWidth = window.innerWidth;
-                    if (screenWidth <= 480) {
-                        wrapper.style.maxHeight = '450px'; // Mobile screens
-                    } else if (screenWidth <= 768) {
-                        wrapper.style.maxHeight = '550px'; // Medium screens
-                    } else {
-                        wrapper.style.maxHeight = '650px'; // Large screens
-                    }
-                }
-            }
-            
-            // Ensure code content can expand properly
-            const codeBlock = pre.querySelector('code');
-            if (codeBlock) {
-                codeBlock.style.width = 'max-content';
-                codeBlock.style.minWidth = '100%';
-            }
-            
-            // Make sure line-content elements can expand properly
-            pre.querySelectorAll('.line-content').forEach(lineContent => {
-                lineContent.style.width = 'max-content';
-                lineContent.style.minWidth = 'max-content';
-                lineContent.style.flex = '0 0 auto';
-            });
-            
-            // Make sure code-line-row elements can expand properly
-            pre.querySelectorAll('.code-line-row').forEach(lineRow => {
-                lineRow.style.width = 'max-content';
-                lineRow.style.minWidth = '100%';
-            });
-            
-            // Check for horizontal scrolling
-            const containerWidth = pre.parentElement.clientWidth;
-            const contentWidth = pre.scrollWidth;
-            
-            if (contentWidth > containerWidth) {
-                // Add class to indicate horizontally scrollable content
-                pre.classList.add('has-horizontal-scroll');
-                
-                // Add a horizontal scroll indicator if not already present
-                if (!pre.querySelector('.horizontal-scroll-indicator')) {
-                    const scrollIndicator = document.createElement('div');
-                    scrollIndicator.className = 'horizontal-scroll-indicator';
-                    scrollIndicator.textContent = 'scroll →';
-                    
-                    pre.appendChild(scrollIndicator);
-                    
-                    // Hide the indicator after scrolling horizontally
-                    pre.addEventListener('scroll', function() {
-                        if (pre.scrollLeft > 0) { // Only hide when scrolling horizontally
-                            scrollIndicator.style.opacity = '0';
-                        } else if (pre.scrollLeft === 0) {
-                            scrollIndicator.style.opacity = '0.7';
-                        }
-                    });
-                }
-            } else {
-                pre.classList.remove('has-horizontal-scroll');
-                
-                // Remove scroll indicator if exists
-                const indicator = pre.querySelector('.horizontal-scroll-indicator');
-                if (indicator) {
-                    indicator.remove();
-                }
-            }
-            
-            // Check for vertical scrolling
-            const containerHeight = pre.clientHeight;
-            const contentHeight = pre.scrollHeight;
-            
-            if (contentHeight > containerHeight) {
-                // Add class to indicate vertically scrollable content
-                pre.classList.add('has-vertical-scroll');
-                
-                // Add a vertical scroll indicator if not already present
-                if (!pre.querySelector('.vertical-scroll-indicator')) {
-                    const verticalIndicator = document.createElement('div');
-                    verticalIndicator.className = 'vertical-scroll-indicator';
-                    verticalIndicator.textContent = 'scroll ↓';
-                    
-                    pre.appendChild(verticalIndicator);
-                    
-                    // Hide the indicator when scrolling vertically
-                    pre.addEventListener('scroll', function() {
-                        if (pre.scrollTop > 10) { // Hide when scrolled down
-                            verticalIndicator.style.opacity = '0';
-                        } else if (pre.scrollTop < 10) { // Show when at top
-                            verticalIndicator.style.opacity = '0.7';
-                        }
-                    });
-                }
-            } else {
-                // Remove the indicator if content is not taller than container
-                const verticalIndicator = pre.querySelector('.vertical-scroll-indicator');
-                if (verticalIndicator) {
-                    verticalIndicator.remove();
-                }
-                pre.classList.remove('has-vertical-scroll');
+        headings.forEach((heading, index) => {
+            if (!heading.id) {
+                heading.id = `heading-${index}`;
             }
         });
-    }
-    
-    // Run on load and resize
-    checkCodeBlockOverflow();
-    
-    // Debounce function to limit how often the resize handler is called
-    function debounce(func, wait) {
-        let timeout;
-        return function() {
-            const context = this;
-            const args = arguments;
-            clearTimeout(timeout);
-            timeout = setTimeout(() => {
-                func.apply(context, args);
-            }, wait);
-        };
-    }
-    
-    // Add resize listener with debounce to improve performance
-    window.addEventListener('resize', debounce(function() {
-        checkCodeBlockOverflow();
-    }, 250)); // Wait 250ms after resize stops before recalculating
-    
-    // Fix any text that might be overflowing
-    document.querySelectorAll('.post-content p, .post-content li, .post-content h1, .post-content h2, .post-content h3, .post-content h4, .post-content h5, .post-content h6').forEach(element => {
-        element.style.overflowWrap = 'break-word';
-        element.style.wordWrap = 'break-word';
-        element.style.wordBreak = 'break-word';
-        element.style.maxWidth = '100%';
-    });
-    
-    // Make sure the post content container is properly set
-    const postContent = document.querySelector('.post-content');
-    if (postContent) {
-        postContent.style.width = '100%';
-        postContent.style.maxWidth = '100%';
-        postContent.style.overflowX = 'hidden'; // Hide overflow at container level
-        postContent.style.overflowWrap = 'break-word';
-        postContent.style.wordWrap = 'break-word';
-        postContent.style.wordBreak = 'break-word';
     }
 });
 </script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -93,6 +93,55 @@ body {
     overflow-x: hidden;
 }
 
+/* Typography: Serif for article content only */
+.post-content {
+    font-family: 'Source Serif Pro', 'Merriweather', Georgia, 'Times New Roman', serif;
+    font-size: 1.125rem; /* 18px */
+    line-height: 1.65;
+    max-width: 100%;
+    margin: 0;
+    color: var(--text-color);
+}
+
+.post-content p {
+    margin-bottom: 1.25rem;
+}
+
+.post-content h1, .post-content h2, .post-content h3,
+.post-content h4, .post-content h5, .post-content h6 {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-weight: 700;
+    color: var(--text-color);
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.3;
+}
+
+.post-content h1 { font-size: 2rem; }
+.post-content h2 { font-size: 1.75rem; }
+.post-content h3 { font-size: 1.5rem; }
+.post-content h4 { font-size: 1.25rem; }
+
+.post-content a {
+    color: var(--link-color);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+}
+
+.post-content a:hover {
+    color: var(--link-hover-color);
+    text-decoration-thickness: 2px;
+}
+
+.post-content blockquote {
+    border-left: 4px solid var(--accent-color);
+    padding-left: 1.25rem;
+    margin: 1.5rem 0;
+    font-style: italic;
+    color: var(--secondary-text);
+}
+
 .site-wrapper {
     flex: 1 0 auto;
     display: flex;
@@ -410,9 +459,9 @@ nav .container {
 }
 
 .post-header {
-    margin-bottom: 2.5rem;
+    margin-bottom: 3rem;
     position: relative;
-    padding: 1.5rem 0;
+    padding: 0 2rem 2rem 2rem;
     width: 100%;
     box-sizing: border-box;
     border-bottom: 1px solid var(--border-color);
@@ -420,25 +469,27 @@ nav .container {
 }
 
 .post-header h1, .post-title {
-    margin-bottom: 1rem;
+    margin: 0 0 1.5rem 0;
     color: var(--text-color);
-    font-size: 2.2rem;
-    line-height: 1.3;
+    font-size: 2.75rem;
+    line-height: 1.2;
     font-weight: 800;
+    letter-spacing: -0.02em;
 }
 
 .post-header .post-description {
-    margin-bottom: 1.2rem;
-    color: var(--text-color);
-    font-size: 1.1rem;
-    line-height: 1.5;
+    margin: 0 0 1.5rem 0;
+    color: var(--secondary-text);
+    font-size: 1.15rem;
+    line-height: 1.6;
     max-width: 90%;
 }
 
 .post-header .post-meta {
-    margin-bottom: 1rem;
-    font-size: 0.95rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.875rem;
     color: var(--text-color);
+    opacity: 0.7;
 }
 
 .post-header .date-category {
@@ -473,6 +524,54 @@ nav .container {
 }
 
 .post-header .tag:hover {
+    background-color: var(--tag-hover-bg);
+}
+
+/* Inline meta bar - date, category, and tags all on one line */
+.post-meta-inline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+}
+
+.post-meta-inline time {
+    color: var(--secondary-text);
+    opacity: 0.75;
+}
+
+.meta-separator {
+    color: var(--secondary-text);
+    opacity: 0.4;
+}
+
+.post-meta-inline .category-link {
+    color: var(--category-text);
+    text-decoration: none;
+    background-color: var(--tag-bg);
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--tag-border);
+    transition: all 0.2s ease;
+}
+
+.post-meta-inline .category-link:hover {
+    background-color: var(--tag-hover-bg);
+}
+
+.post-meta-inline .tag-inline {
+    color: var(--tag-text);
+    text-decoration: none;
+    font-size: 0.875rem;
+    background-color: var(--tag-bg);
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--tag-border);
+    transition: background-color 0.2s ease;
+}
+
+.post-meta-inline .tag-inline:hover {
     background-color: var(--tag-hover-bg);
 }
 
@@ -1867,52 +1966,6 @@ pre code {
     width: 100%;
 }
 
-/* Code block actions container */
-.code-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-/* Toggle expand/collapse button */
-.toggle-code-height {
-    background-color: transparent;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-}
-
-.toggle-code-height:hover {
-    background-color: var(--accent-color);
-    color: white;
-}
-
-/* Expanded code block */
-.code-expanded {
-    max-height: none !important;
-}
-
-.copy-code-button {
-    background-color: transparent;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.copy-code-button:hover {
-    background-color: var(--accent-color);
-    color: white;
-}
-
 .language-indicator {
     font-size: 0.75rem;
     color: var(--secondary-text);
@@ -1952,63 +2005,39 @@ code {
     position: relative;
 }
 
-/* Copy button container and button styling */
-.copy-button-container {
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 8px;
-    z-index: 1000; /* Ensure it's above everything else */
-    pointer-events: none; /* Allow clicks to pass through container */
-}
-
-.copy-button {
-    background-color: var(--accent-color);
-    color: white;
-    border: none;
+/* Copy button styling - integrated into code header */
+.code-header .copy-button {
+    background: transparent;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
     cursor: pointer;
-    transition: all 0.2s ease;
-    opacity: 0.9; /* Increased opacity for better visibility */
     display: flex;
     align-items: center;
-    gap: 0.25rem;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-    pointer-events: auto; /* Ensure button is clickable */
+    justify-content: center;
+    transition: all 0.2s ease;
+    color: var(--secondary-text);
+    gap: 0;
 }
 
-.copy-button:hover {
-    opacity: 1;
-    transform: translateY(-1px);
-    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+.code-header .copy-button:hover {
+    background: var(--accent-color);
+    color: white;
+    border-color: var(--accent-color);
 }
 
-/* Dark mode specific styling */
-.dark-theme .copy-button {
-    background-color: #4a9ae1; /* Explicit color for dark mode */
-    color: #ffffff;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
-    border: 1px solid rgba(255, 255, 255, 0.1); /* Add subtle border */
+.code-header .copy-button svg {
+    width: 16px;
+    height: 16px;
 }
 
-.dark-theme .copy-button:hover {
-    background-color: #5aafe1; /* Lighter on hover */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
-    border-color: rgba(255, 255, 255, 0.2);
+.code-header .copy-button.copied {
+    background: var(--success-color, #22c55e);
+    color: white;
+    border-color: var(--success-color, #22c55e);
 }
 
-.copy-button svg {
-    width: 14px;
-    height: 14px;
-}
-
-.dark-theme .copy-button svg {
-    stroke: #ffffff;
-}
-
-/* For backwards compatibility with any existing floating-copy-button elements */
+/* For backwards compatibility */
 .floating-copy-button {
     display: none; /* Hide any existing floating copy buttons */
 }
@@ -2177,32 +2206,6 @@ code {
     background-color: #151515;
 }
 
-.copy-code-button {
-    background-color: var(--accent-color);
-    border: none;
-    border-radius: 4px;
-    color: white;
-    padding: 0.4rem 0.8rem;
-    font-size: 0.8rem;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-weight: 500;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    white-space: nowrap;
-    margin-left: 0.5rem;
-}
-
-.copy-code-button:hover {
-    background-color: var(--accent-color-dark, var(--accent-color));
-    transform: translateY(-1px);
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
-}
-
-.copy-code-button:active {
-    transform: translateY(0);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-}
-
 .language-indicator {
     font-size: 0.75rem;
     color: var(--secondary-text);
@@ -2226,12 +2229,12 @@ code {
     }
     
     .post-header {
-        padding: 1.2rem 1rem;
+        padding: 0 1rem 1.5rem 1rem;
     }
-    
+
     .post-header h1 {
-        font-size: 1.8rem;
-        line-height: 1.3;
+        font-size: 2rem;
+        line-height: 1.2;
     }
     
     .site-subtitle {
@@ -2268,12 +2271,7 @@ code {
         padding: 0.2rem 0.4rem;
         margin-bottom: 0.25rem;
     }
-    
-    .copy-code-button {
-        font-size: 0.7rem;
-        padding: 0.2rem 0.5rem;
-    }
-    
+
     .code-table {
         display: table;
         table-layout: auto;
@@ -2445,12 +2443,7 @@ code {
         padding: 0.15rem 0.3rem;
         max-width: 40%;
     }
-    
-    .copy-code-button {
-        font-size: 0.65rem;
-        padding: 0.15rem 0.4rem;
-    }
-    
+
     code {
         font-size: 0.95em; /* Match post-content font size */
         padding: 0.15em 0.3em;
@@ -2504,12 +2497,12 @@ code {
     }
     
     .post-header {
-        padding: 1rem 0.75rem;
+        padding: 0 0.75rem 1.25rem 0.75rem;
     }
-    
+
     .post-header h1 {
-        font-size: 1.6rem;
-        line-height: 1.3;
+        font-size: 1.75rem;
+        line-height: 1.2;
     }
     
     .post-header .post-description {
@@ -2662,22 +2655,7 @@ code {
         border-top-left-radius: 6px;
         border-top-right-radius: 6px;
     }
-    
-    .copy-code-button {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.7rem;
-        border-radius: 4px;
-        border: 1px solid var(--border-color);
-        background-color: var(--button-bg);
-        color: var(--button-text);
-        cursor: pointer;
-        transition: all 0.2s ease;
-    }
 
-    .copy-code-button:hover {
-        background-color: var(--button-hover-bg);
-    }
-    
     .language-indicator {
         font-size: 0.65rem;
         padding: 0.3rem 0.5rem;
@@ -3122,55 +3100,112 @@ body:has(.home-wrapper) > .container > *:not(.home-wrapper) {
     text-decoration: none;
 }
 
-/* Back button styles */
-.post-header {
-    position: relative;
-    padding: 1.5rem 1.5rem;
-}
-
-.post-header-top {
-    display: flex;
-    justify-content: flex-start;
-    margin-bottom: 1.2rem;
-}
-
-.back-button {
+/* Back link - minimal icon style */
+.back-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0;
-    padding: 0.5rem 0.75rem;
-    font-size: 0.9rem;
-    font-weight: 500;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    margin-bottom: 0.75rem;
+    flex-shrink: 0;
     color: var(--secondary-text);
-    background-color: var(--secondary-bg);
-    border: 1px solid var(--border-color);
+    background: transparent;
     border-radius: 6px;
-    cursor: pointer;
+    text-decoration: none;
     transition: all 0.2s ease;
 }
 
-.back-button::before {
-    content: "";
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='19' y1='12' x2='5' y2='12'%3E%3C/line%3E%3Cpolyline points='12 19 5 12 12 5'%3E%3C/polyline%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
+.back-link svg {
     transition: transform 0.2s ease;
 }
 
-.back-button:hover {
-    color: var(--accent-color);
-    background-color: var(--secondary-bg);
+.back-link:hover {
+    color: var(--text-color);
+    background: var(--code-bg);
 }
 
-.back-button:hover::before {
-    transform: translateX(-3px);
+.back-link:hover svg {
+    transform: translateX(-2px);
 }
 
-.back-button:focus {
-    outline: none;
+.back-link:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
+/* ============================================================================
+   Simplified Code Block Styles for Highlight.js
+   ============================================================================ */
+
+/* Override existing code block styles with simpler version */
+pre {
+    background-color: var(--code-bg);
+    border-radius: 6px;
+    margin: 1.5rem 0;
+    border: 1px solid var(--border-color);
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+pre code {
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    display: block;
+    white-space: pre;
+}
+
+.code-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background-color: var(--code-bg);
+    border: 1px solid var(--border-color);
+    border-bottom: none;
+    border-radius: 6px 6px 0 0;
+    font-size: 0.8rem;
+}
+
+.code-header + pre {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    margin-top: 0;
+}
+
+.language-indicator {
+    font-weight: 600;
+    color: var(--secondary-text);
+    text-transform: capitalize;
+}
+
+.code-block-wrapper {
+    margin: 1.5rem 0;
+}
+
+/* Responsive improvements for typography and code blocks */
+@media (max-width: 768px) {
+    .post-content {
+        font-size: 1rem;
+    }
+
+    pre {
+        font-size: 0.8rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .post-content {
+        font-size: 0.95rem;
+    }
+
+    pre {
+        font-size: 0.75rem;
+    }
+
+    .code-header {
+        padding: 0.4rem 0.75rem;
+        font-size: 0.75rem;
+    }
 }


### PR DESCRIPTION
- Increase title size to 2.75rem with tighter line-height and letter-spacing
- Combine date, category, and tags into single inline meta bar
- Restore colored pill styling for tags and category links
- Remove top padding from header for cleaner separator look
- Increase overall spacing for more spacious feel
- Tags now display with # prefix inline with meta info